### PR TITLE
Update video_merge.py to prevent Runtime Error

### DIFF
--- a/video_merge.py
+++ b/video_merge.py
@@ -23,7 +23,9 @@ class VideoMerge:
             Video_A = Video_A.unsqueeze(0)
         if Video_B.dim() == 3:
             Video_B = Video_B.unsqueeze(0)
-
+        # If the tensors are on different devices, move to the same device
+        if Video_A.device != Video_B.device:
+            Video_B = Video_B.to(Video_A.device)
         # Concatenate the images along the first dimension (batch dimension)
         Video = torch.cat((Video_A, Video_B), dim=0)
         


### PR DESCRIPTION
Fixes: Runtime Error: Expected all tensors to be on the same device, but found at least two devices, cpu and cuda:0

For those using low VRAM, work is some times offloaded to the CPU.  When this happens Video_A might end up on a different device than Video_B.  This change checks for this condition and resolves it to prevent errors being thrown in the workflow.